### PR TITLE
Update Relay Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ https://relay.mastodon.kr/inbox
 ```
 https://aprelay.thebackupbox.net/inbox
 https://federation.stream/inbox | DNS can't be resolved at the moment
-https://relay.asonix.dog/inbox
+https://relay.asonix.dog/inbox | Owner is rather picky about instances that join, good luck.
 https://relay.chemnitz.social/inbox
 https://relay.darmstadt.social/inbox
 https://relay.dog/inbox


### PR DESCRIPTION
Re: https://relay.asonix.dog/inbox

Owner is picky about who can join relay, picks and chooses at own discretion.