### PR TITLE
Update relay list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ https://relay.toot.yukimochi.jp/inbox
 https://relay.uggs.io/actor
 https://relay.wagnersnetz.de/actor
 https://relay.wig.gl/actor
+https://relay.dog/actor
+https://relay.darmstadt.social/actor
 ```
 
 ## ✅🚫 relays that are restricted with allowlists
@@ -52,20 +54,9 @@ https://relay.chocoflan.net/actor | Only for primarily Spanish-language instance
 ## ❔ relays that maybe? work
 
 ```
-https://aprelay.thebackupbox.net/inbox
-https://federation.stream/inbox | DNS can't be resolved at the moment
-https://relay.chemnitz.social/inbox
-https://relay.darmstadt.social/inbox
-https://relay.dog/inbox
-https://relay.fediverse.life/inbox
-https://relay.kretschmann.social/inbox
-https://relay.mastodon.libresilicon.com/inbox
-https://relay.mastodon.scot/inbox
-https://relay.nfld.uk/inbox
-https://relay.nsupdate.info/inbox
-https://relay.phreedom.club/inbox
-https://relay.social.firc.de/inbox
-https://relay.glauca.space/inbox
+https://relay.chemnitz.social/inbox | Connection times out
+https://relay.kretschmann.social/inbox | Redirects to https://kretschmann.social/
+https://relay.glauca.space/inbox | Slow/unresponsive
 ```
 
 ## ❌ relays that DON'T work
@@ -114,6 +105,15 @@ https://mastodon-relay.moew.science/inbox | 404
 https://relay.douzepoints.social/inbox | 404
 https://relay.gruenehoelle.nl/inbox | 404
 https://relay2.mastodon.ml/inbox | 502 Bad Gateway
+https://relay.fediverse.life/inbox | DNS Record doesn't exist
+https://relay.nsupdate.info/inbox | Offline for maintenance
+https://relay.nfld.uk/inbox | 410 Gone
+https://relay.mastodon.scot/inbox | DNS Record doesn't exist
+https://relay.mastodon.libresilicon.com/inbox | SSL Cert invalid
+https://relay.social.firc.de/inbox | DNS Record doesn't exist
+https://relay.phreedom.club/inbox | DNS Record doesn't exist
+https://federation.stream/inbox | DNS Record doesn't exist
+https://aprelay.thebackupbox.net/inbox | Snarky error messages?
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ if you want to add a relay to your:
 
 ### Pleroma Instance
 - Copy the URL & replace */inbox* with */actor*
+- Note that some relays only work with */actor* and not */inbox*
 
 ## ✅ active working relays
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ https://relay.wagnersnetz.de/inbox
 https://relay.wig.gl/inbox
 https://relay.dog/inbox
 https://relay.darmstadt.social/inbox
-https://relay.gruenehoelle.nl/inbox
 https://mastodon-relay.moew.science/inbox
 https://relay.douzepoints.social/inbox
 ```
@@ -59,7 +58,6 @@ https://relay.chocoflan.net/inbox | Only for primarily Spanish-language instance
 https://relay.chemnitz.social/inbox | Connection times out
 https://relay.kretschmann.social/inbox | Redirects to https://kretschmann.social/
 https://relay.glauca.space/inbox | Slow/unresponsive
-https://aprelay.thebackupbox.net/inbox | Snarky error messages?
 ```
 
 ## ❌ relays that DON'T work
@@ -113,6 +111,7 @@ https://relay.mastodon.libresilicon.com/inbox | SSL Cert invalid
 https://relay.social.firc.de/inbox | DNS Record doesn't exist
 https://relay.phreedom.club/inbox | DNS Record doesn't exist
 https://federation.stream/inbox | DNS Record doesn't exist
+https://aprelay.thebackupbox.net/inbox | Bad certificate; Common name invalid
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ if you want to add a relay to your:
 
 ### Pleroma Instance
 - Copy the URL & replace */inbox* with */actor*
-- Note that some relays *only* work with */actor* and not */inbox*
 
 ## ✅ active working relays
 
@@ -19,24 +18,24 @@ https://relay.an.exchange/inbox
 https://relay.beckmeyer.us/inbox
 https://relay.fedi.agency/inbox
 https://relay.fedinet.social/inbox
-https://relay.flm9.me/actor
-https://relay.froth.zone/actor
+https://relay.flm9.me/inbox
+https://relay.froth.zone/inbox
 https://relay.gruenehoelle.nl/inbox
 https://relay.homunyan.com/inbox
-https://relay.intahnet.co.uk/actor
-https://relay.libranet.de/actor
+https://relay.intahnet.co.uk/inbox
+https://relay.libranet.de/inbox
 https://relay.minecloud.ro/inbox
 https://relay.mistli.net/inbox
-https://relay.pissdichal.de/actor
+https://relay.pissdichal.de/inbox
 https://relay.toot.yukimochi.jp/inbox
-https://relay.uggs.io/actor
-https://relay.wagnersnetz.de/actor
-https://relay.wig.gl/actor
-https://relay.dog/actor
-https://relay.darmstadt.social/actor
-https://relay.gruenehoelle.nl/actor
-https://mastodon-relay.moew.science/actor
-https://relay.douzepoints.social/actor
+https://relay.uggs.io/inbox
+https://relay.wagnersnetz.de/inbox
+https://relay.wig.gl/inbox
+https://relay.dog/inbox
+https://relay.darmstadt.social/inbox
+https://relay.gruenehoelle.nl/inbox
+https://mastodon-relay.moew.science/inbox
+https://relay.douzepoints.social/inbox
 ```
 
 ## ✅🚫 relays that are restricted with allowlists
@@ -50,8 +49,8 @@ https://relay.breakblocks.social/inbox | Only for instances primarily based arou
 https://relay.dariox.club/inbox | Contact @kate@dariox.club prior to joining.
 https://relay.mastodon.kr/inbox
 https://streamb0x.de/inbox | Contact admin@joinmastodon.de to join the relay
-https://relay.neovibe.app/actor | Must be approved by NeoVibe admin. For faster review of your instance, please send a Direct Messsage to @neovibe@neovibe.app
-https://relay.chocoflan.net/actor | Only for primarily Spanish-language instances.
+https://relay.neovibe.app/inbox | Must be approved by NeoVibe admin. For faster review of your instance, please send a Direct Messsage to @neovibe@neovibe.app
+https://relay.chocoflan.net/inbox | Only for primarily Spanish-language instances.
 ```
 
 ## ❔ relays that maybe? work
@@ -59,7 +58,8 @@ https://relay.chocoflan.net/actor | Only for primarily Spanish-language instance
 ```
 https://relay.chemnitz.social/inbox | Connection times out
 https://relay.kretschmann.social/inbox | Redirects to https://kretschmann.social/
-https://relay.glauca.space/actor | Slow/unresponsive
+https://relay.glauca.space/inbox | Slow/unresponsive
+https://aprelay.thebackupbox.net/inbox | Snarky error messages?
 ```
 
 ## ❌ relays that DON'T work
@@ -113,7 +113,6 @@ https://relay.mastodon.libresilicon.com/inbox | SSL Cert invalid
 https://relay.social.firc.de/inbox | DNS Record doesn't exist
 https://relay.phreedom.club/inbox | DNS Record doesn't exist
 https://federation.stream/inbox | DNS Record doesn't exist
-https://aprelay.thebackupbox.net/inbox | Snarky error messages?
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ if you want to add a relay to your:
 
 ### Pleroma Instance
 - Copy the URL & replace */inbox* with */actor*
-- Note that some relays only work with */actor* and not */inbox*
+- Note that some relays *only* work with */actor* and not */inbox*
 
 ## ✅ active working relays
 
@@ -34,6 +34,9 @@ https://relay.wagnersnetz.de/actor
 https://relay.wig.gl/actor
 https://relay.dog/actor
 https://relay.darmstadt.social/actor
+https://relay.gruenehoelle.nl/actor
+https://mastodon-relay.moew.science/actor
+https://relay.douzepoints.social/actor
 ```
 
 ## ✅🚫 relays that are restricted with allowlists
@@ -56,7 +59,7 @@ https://relay.chocoflan.net/actor | Only for primarily Spanish-language instance
 ```
 https://relay.chemnitz.social/inbox | Connection times out
 https://relay.kretschmann.social/inbox | Redirects to https://kretschmann.social/
-https://relay.glauca.space/inbox | Slow/unresponsive
+https://relay.glauca.space/actor | Slow/unresponsive
 ```
 
 ## ❌ relays that DON'T work
@@ -101,9 +104,6 @@ https://relay.freespeech.club/inbox | 502 Bad Gateway
 https://relay.k3tan.com/inbox | Error 1033
 https://relay.retronerd.at/inbox | DNS record does not exist
 https://relay.social.tigwali.fr/inbox | 504 Gateway time-out
-https://mastodon-relay.moew.science/inbox | 404
-https://relay.douzepoints.social/inbox | 404
-https://relay.gruenehoelle.nl/inbox | 404
 https://relay2.mastodon.ml/inbox | 502 Bad Gateway
 https://relay.fediverse.life/inbox | DNS Record doesn't exist
 https://relay.nsupdate.info/inbox | Offline for maintenance

--- a/README.md
+++ b/README.md
@@ -14,29 +14,23 @@ if you want to add a relay to your:
 ## ✅ active working relays
 
 ```
-
-https://mastodon-relay.moew.science/inbox
 https://relay.an.exchange/inbox
 https://relay.beckmeyer.us/inbox
-https://relay.chocoflan.net/inbox
-https://relay.douzepoints.social/inbox
 https://relay.fedi.agency/inbox
 https://relay.fedinet.social/inbox
-https://relay.flm9.me/inbox
-https://relay.froth.zone/inbox
-https://relay.glauca.space/inbox
+https://relay.flm9.me/actor
+https://relay.froth.zone/actor
 https://relay.gruenehoelle.nl/inbox
 https://relay.homunyan.com/inbox
-https://relay.intahnet.co.uk/inbox
-https://relay.libranet.de/inbox
+https://relay.intahnet.co.uk/actor
+https://relay.libranet.de/actor
 https://relay.minecloud.ro/inbox
 https://relay.mistli.net/inbox
-https://relay.neovibe.app/inbox
-https://relay.pissdichal.de/inbox
+https://relay.pissdichal.de/actor
 https://relay.toot.yukimochi.jp/inbox
-https://relay.uggs.io/inbox
-https://relay.wagnersnetz.de/inbox
-https://relay.wig.gl/inbox
+https://relay.uggs.io/actor
+https://relay.wagnersnetz.de/actor
+https://relay.wig.gl/actor
 ```
 
 ## ✅🚫 relays that are restricted with allowlists
@@ -50,6 +44,8 @@ https://relay.breakblocks.social/inbox | Only for instances primarily based arou
 https://relay.dariox.club/inbox | Contact @kate@dariox.club prior to joining.
 https://relay.mastodon.kr/inbox
 https://streamb0x.de/inbox | Contact admin@joinmastodon.de to join the relay
+https://relay.neovibe.app/actor | Must be approved by NeoVibe admin. For faster review of your instance, please send a Direct Messsage to @neovibe@neovibe.app
+https://relay.chocoflan.net/actor | Only for primarily Spanish-language instances.
 ```
 
 ## ❔ relays that maybe? work
@@ -68,7 +64,7 @@ https://relay.nfld.uk/inbox
 https://relay.nsupdate.info/inbox
 https://relay.phreedom.club/inbox
 https://relay.social.firc.de/inbox
-https://relay2.mastodon.ml/inbox
+https://relay.glauca.space/inbox
 ```
 
 ## ❌ relays that DON'T work
@@ -113,6 +109,10 @@ https://relay.freespeech.club/inbox | 502 Bad Gateway
 https://relay.k3tan.com/inbox | Error 1033
 https://relay.retronerd.at/inbox | DNS record does not exist
 https://relay.social.tigwali.fr/inbox | 504 Gateway time-out
+https://mastodon-relay.moew.science/inbox | 404
+https://relay.douzepoints.social/inbox | 404
+https://relay.gruenehoelle.nl/inbox | 404
+https://relay2.mastodon.ml/inbox | 502 Bad Gateway
 ```
 
 


### PR DESCRIPTION
List currently has a number of relays that either no longer work, only respond at the `/actor` endpoint, or have no valid DNS records.