### PR TITLE
add relay.bau-ha.us

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ https://relay.breakblocks.social/inbox | Only for instances primarily based arou
 https://relay.dariox.club/inbox | Contact @kate@dariox.club prior to joining.
 https://relay.mastodon.kr/inbox
 https://streamb0x.de/inbox | Contact admin@joinmastodon.de to join the relay
+https://relay.bau-ha.us | thuringia + middle/east germany / non-profit / infosec contact _mt@social.bau-ha.us prior to joining. 
 ```
 
 ## ❔ relays that maybe? work


### PR DESCRIPTION
relay for thuringia + middle/east germany / non-profit / infosec contact https://social.bau-ha.us/@_mt prior to joining. 