### PR TITLE
fix relay.bau-ha.us url

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ https://relay.breakblocks.social/inbox | Only for instances primarily based arou
 https://relay.dariox.club/inbox | Contact @kate@dariox.club prior to joining.
 https://relay.mastodon.kr/inbox
 https://streamb0x.de/inbox | Contact admin@joinmastodon.de to join the relay
-https://relay.bau-ha.us | thuringia + middle/east germany / non-profit / infosec contact _mt@social.bau-ha.us prior to joining.
+https://relay.bau-ha.us/inbox | thuringia + middle/east germany / non-profit / infosec contact _mt@social.bau-ha.us prior to joining.
 https://relay.neovibe.app/inbox | Must be approved by NeoVibe admin. For faster review of your instance, please send a Direct Messsage to @neovibe@neovibe.app
 https://relay.chocoflan.net/inbox | Only for primarily Spanish-language instances.
 ```


### PR DESCRIPTION
missed in the /inbox path - this is probably irritating for new users